### PR TITLE
Don't require spaces before function parens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
     "space-after-keywords": 2,
     "space-before-keywords": 2,
     "space-before-blocks": 2,
+    "space-before-function-paren": 0,
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
     "space-unary-ops": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,6 @@
     "space-after-keywords": 2,
     "space-before-keywords": 2,
     "space-before-blocks": 2,
-    "space-before-function-paren": 2,
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
     "space-unary-ops": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -101,7 +101,8 @@
     "es6": true
   },
   "ecmaFeatures": {
-    "jsx": true
+    "jsx": true,
+    "modules": true
   },
   "plugins": [
     "react"


### PR DESCRIPTION
As this is not canonical ES6 style https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes