### PR TITLE
Fix `import declaration` bug - Use `babel-eslint`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "parser": "babel-eslint",
   "rules": {
     "strict": [
       2,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/dabapps/eslint-config",
   "dependencies": {
+    "babel-eslint": "=4.1.6",
     "eslint": "=1.5.0",
     "eslint-plugin-react": "=3.4.2"
   }


### PR DESCRIPTION
### Update - How to fix per project

For each project you can use this config but extend it:

    {
      "extends": "./node_modules/eslint-config/.eslintrc",
      "parser": "babel-eslint"
    }

Also don't forget to `npm install babel-eslint --save-dev`.